### PR TITLE
pygame in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ packaging==24.1
 pillow==10.3.0
 websockets==12.0
 yarl==1.9.4
+pygame==2.6.0


### PR DESCRIPTION
tkinter was also missing when loading `python3 main.py`, I used 
```
sudo apt-get install python3-tk
```